### PR TITLE
Updated tax_agg.R to convert matrix to data.frame

### DIFF
--- a/R/tax_agg.R
+++ b/R/tax_agg.R
@@ -50,6 +50,11 @@
 #' }
 tax_agg <- function(x, rank, db = 'ncbi', ...) 
 {
+  if(is.matrix(x))
+  {
+    if(is.null(colnames(x))) stop("The community data matrix must have named columns")
+    x <- data.frame(x)
+  }
   # bring to long format
   x$rownames <- rownames(x)
   df_m <- melt(x, id = 'rownames')


### PR DESCRIPTION
Re: ropensci/taxize#224

If the community data matrix is indeed a `matrix` object, the function converts it to `data.frame` automatically
