### PR TITLE
Minor addition to ncbi_search

### DIFF
--- a/R/ncbi_children.R
+++ b/R/ncbi_children.R
@@ -41,7 +41,8 @@ ncbi_children <- function(name = NULL, id = NULL, start = 0, max_return = 1000,
   # Constants --------------------------------------------------------------------------------------
   ambiguous_regex <- paste(sep = "|", "unclassified", "environmental", "uncultured", "unknown",
                            "unidentified", "candidate", "sp\\.", "s\\.l\\.", "sensu lato", "clone",
-                           "miscellaneous", "candidatus", "affinis", "aff\\.")
+                           "miscellaneous", "candidatus", "affinis", "aff\\.", "incertae sedis", 
+                           "mixed", "samples", "libaries")
   base_url <- "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=taxonomy"
   # Argument validation ----------------------------------------------------------------------------
   if (sum(c(is.null(name), is.null(id))) != 1) {


### PR DESCRIPTION
I added a few terms to the list that indicates ambiguous taxa in `ncbi_children`: "incertae sedis", "mixed", "samples", "libaries"
