### PR TITLE
made genbank2uid accept multiple ids

### DIFF
--- a/R/genbank2uid.R
+++ b/R/genbank2uid.R
@@ -31,7 +31,7 @@ genbank2uid <- function(id, ...){
     Sys.sleep(0.34) # NCBI limits requests to three per second
     return(result)
   }
-  result <- as.uid(vapply(id, process_one, character(1)))
+  result <- as.uid(unname(vapply(id, process_one, character(1))))
   matched <- rep("found", length(result))
   matched[is.na(result)] <- "not found"
   attr(result, "match") <- matched


### PR DESCRIPTION
The `genbank2uid` function is handy, but does not accept multiple ids at once, as would be expected by most R users. I made it process multiple ids by repeating the original function's code for each id and combining the result. There is one query to ncbi per id, so it might be more efficient to query multiple ids at once, if posible, since ncbi limits querys to 3 per second. However, I have not looked into that yet. 
