### PR TITLE
patch children.default to make more extensible and the error messages more sensible

### DIFF
--- a/R/children.R
+++ b/R/children.R
@@ -53,33 +53,42 @@ children <- function(...){
 #' @rdname children
 children.default <- function(x, db = NULL, ...)
 {
-  if (is.null(db))
+  if (is.null(db)){
     stop("Must specify db value!")
-  
-  if (db == 'itis') {
-    id <- get_tsn(x, ...)
-    out <- children(id, ...)
   }
-  if (db == 'col') {
-    id <- get_colid(x, ...)
-    out <- children(id, ...)
-  }
-  if (db == 'ncbi') {
-     if (all(grepl("^[[:digit:]]*$", x))) {
-       id <- x
-       class(id) <- "uid"
-       out <- children(id, ...)
-     } else {
-       out <- ncbi_children(name = x, ...)
-       class(out) <- 'children'
-       attr(out, 'db') <- 'ncbi'
-     }
-  }
-#   if (db == 'ubio') {
-#     id <- get_ubioid(x, ...)
-#     out <- children(id, ...)
-#     names(out) <- x
-#   }
+
+
+  switch(db,
+         itis = {
+           id <- get_tsn(x, ...)
+           out <- children(id, ...)
+         },
+
+         col = {
+           id <- get_colid(x, ...)
+           out <- children(id, ...)
+         },
+
+         ncbi = {
+           if (all(grepl("^[[:digit:]]*$", x))) {
+             id <- x
+             class(id) <- "uid"
+             out <- children(id, ...)
+           } else {
+             out <- ncbi_children(name = x, ...)
+             class(out) <- 'children'
+             attr(out, 'db') <- 'ncbi'
+           }
+         },
+
+#        ubio = {
+#          id <- get_ubioid(x, ...)
+#          out <- children(id, ...)
+#          names(out) <- x
+#        },
+
+         stop("the provided db value was not recognised")
+  )
   names(out) <- x
   return(out)
 }


### PR DESCRIPTION
children.default currently contains a series of if-checks over the value of "db", with different behaviour for each outcome...but no handling for the situation where a db is specified (so, not NULL) but not matched by one of the if checks. This currently leads to a confusing error (object 'out' not found).

This patch replaces the if-checks with a switch to make the set more extensible, and includes within that switch a default option for the situation where a db parameter is !NULL but also not recognised - avoiding the confusing error message and replacing it with "the provided db value was not recognised" (which uses the same syntax as the existing error messages).
