### PR TITLE
gnr_resolve: fields='all' vs fields='minimal'

### DIFF
--- a/R/gnr_resolve.R
+++ b/R/gnr_resolve.R
@@ -153,6 +153,7 @@ gnr_resolve <- function(names, data_source_ids = NULL, resolve_once = FALSE,
 
   # check for empty data object
   drill <- tryCatch(data_[[1]], error = function(e) e)
+  to_rename <- c("original_name", "supplied_name_string", "name_string", "canonical_form")
   if (inherits(drill, "simpleError")) {
     out <- data.frame(NULL)
   } else {
@@ -162,7 +163,7 @@ gnr_resolve <- function(names, data_source_ids = NULL, resolve_once = FALSE,
       } else {
         x[[2]]
       }), stringsAsFactors = FALSE))
-      names(data_2)[c(1,2,3,6)] <- c("user_supplied_name", "submitted_name", "matched_name", "matched_name2")
+      names(data_2)[names(data_2) %in% to_rename] <- c("user_supplied_name", "submitted_name", "matched_name", "matched_name2")
       data_2$matched_name <- as.character(data_2$matched_name)
       data_2$data_source_title <- as.character(data_2$data_source_title)
       data_2$matched_name2 <- as.character(data_2$matched_name2)
@@ -193,7 +194,7 @@ gnr_resolve <- function(names, data_source_ids = NULL, resolve_once = FALSE,
       } else {
         x[[2]]
       }), stringsAsFactors = FALSE))
-      names(data_2_preferred)[c(1,2,3,6)] <- c("user_supplied_name", "submitted_name", "matched_name", "matched_name2")
+      names(data_2_preferred)[names(data_2_preferred) %in% to_rename] <- c("user_supplied_name", "submitted_name", "matched_name", "matched_name2")
       data_2_preferred$matched_name <- as.character(data_2_preferred$matched_name)
       data_2_preferred$data_source_title <- as.character(data_2_preferred$data_source_title)
       data_2_preferred$matched_name2 <- as.character(data_2_preferred$matched_name2)


### PR DESCRIPTION
I have never used this package, so I am not sure if this is the intended behavior, but `$matched_name` for `fields = 'all'` and `fields = 'minimal'` give different results

```r
devtools::install_github('ropensci/taxize')
library('taxize')
tmp1 <- gnr_resolve(names = c("Asteraceae", "Plantae"), fields = 'all')$matched_name
tmp2 <- gnr_resolve(names = c("Asteraceae", "Plantae"), fields = 'minimal')$matched_name

identical(tmp1, tmp2)
# [1] FALSE

head(tmp1)
# [1] "1"  "3"  "4"  "7"  "9"  "12"
head(tmp2)
# [1] "Asteraceae" "Asteraceae" "Asteraceae" "Asteraceae" "Asteraceae" "Asteraceae"
```

Since the columns are being referenced by index instead of by name, when `fields = 'all'`, the same fields below are not being selected.

```
#            names.data_ for fields = 'minimal'
# 1        original_name ##
# 2 supplied_name_string ##
# 3          name_string ##
# 4    data_source_title
# 5                score
# 6       canonical_form ##

#                  names.data_ for fields = 'all'
# 1              original_name ##
# 2       supplied_name_string ##
# 3             data_source_id ##
# 4          data_source_title
# 5                   gni_uuid
# 6                name_string ##
# 7             canonical_form
# 8        classification_path
# 9  classification_path_ranks
# 10   classification_path_ids
# 11                  taxon_id
# 12             edit_distance
# 13                match_type
# 14                  prescore
# 15                     score
# 16                  local_id
# 17                       url
# 18                 global_id
```

The results are the same here

```r
devtools::install_github('raredd/taxize')
library('taxize')
tmp1 <- gnr_resolve(names = c("Asteraceae", "Plantae"), fields = 'all')$matched_name
tmp2 <- gnr_resolve(names = c("Asteraceae", "Plantae"), fields = 'minimal')$matched_name

identical(tmp1, tmp2)
# [1] TRUE

head(tmp1)
# [1] "Asteraceae" "Asteraceae" "Asteraceae" "Asteraceae" "Asteraceae" "Asteraceae"
```