### PR TITLE
fix NCBI ID access in `downstream` function

### DIFF
--- a/R/downstream.R
+++ b/R/downstream.R
@@ -141,7 +141,7 @@ downstream.default <- function(x, db = NULL, downto = NULL,
 process_stream_ids <- function(input, db, fxn, ...){
   g <- tryCatch(as.numeric(as.character(input)), warning = function(e) e)
   if (is(g, "numeric") || is.character(input) && grepl("[[:digit:]]", input)) {
-    as_fxn <- switch(db, itis = as.tsn, col = as.colid, gbif = as.gbifid)
+    as_fxn <- switch(db, itis = as.tsn, col = as.colid, gbif = as.gbifid, ncib = as.uid)
     as_fxn(input, check = FALSE)
   } else {
     eval(fxn)(input, ...)

--- a/R/downstream.R
+++ b/R/downstream.R
@@ -141,7 +141,7 @@ downstream.default <- function(x, db = NULL, downto = NULL,
 process_stream_ids <- function(input, db, fxn, ...){
   g <- tryCatch(as.numeric(as.character(input)), warning = function(e) e)
   if (is(g, "numeric") || is.character(input) && grepl("[[:digit:]]", input)) {
-    as_fxn <- switch(db, itis = as.tsn, col = as.colid, gbif = as.gbifid, ncib = as.uid)
+    as_fxn <- switch(db, itis = as.tsn, col = as.colid, gbif = as.gbifid, ncbi = as.uid)
     as_fxn(input, check = FALSE)
   } else {
     eval(fxn)(input, ...)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix a little bug that prevented NCBI IDs from being used in the `downstream` function.

## Example

Previously the following failed as so:

```r
> downstream(2, downto='class', db='ncbi')
Error in as_fxn(input, check = FALSE) : could not find function "as_fxn"
```

While using scientific names in place of IDs did work:

```r
downstream('Bacteria', downto='class', db='ncbi')
```

Just adding `ncbi = as_uid` to the switch statement that creates `as_fxn` solves this problem.
