### PR TITLE
Type consistency in `children` output

### DIFF
--- a/R/ncbi_children.R
+++ b/R/ncbi_children.R
@@ -92,8 +92,12 @@ ncbi_children <- function(name = NULL, id = NULL, start = 0, max_return = 1000,
     children_uid <- xml2::xml_text(xml2::xml_find_all(results, "//eSearchResult/IdList/Id"))
     if (length(children_uid) == 0) {
       if (out_type == "summary") {
-        output <- data.frame(childtaxa_id = numeric(), childtaxa_name = character(),
-                             childtaxa_rank = character())
+        output <- data.frame(
+          childtaxa_id     = character(),
+          childtaxa_name   = character(),
+          childtaxa_rank   = character(),
+          stringsAsFactors = FALSE
+        )
       } else {
         output <- numeric()
       }

--- a/tests/testthat/test-children.R
+++ b/tests/testthat/test-children.R
@@ -31,6 +31,28 @@ test_that("queries with no results fail well", {
   expect_equal(NROW(aa[[1]]), 0)
 })
 
+test_that("itis types are correct", {
+  skip_on_cran()
+
+  itis_expected_col_types <- c(
+      parentname = 'character',
+      parenttsn  = 'character',
+      rankname   = 'character',
+      taxonname  = 'character',
+      tsn        = 'character'
+    )
+  # for no result
+  expect_equal(
+    sapply(children(1234123434, 'itis')[['1234123434']], class), 
+    itis_expected_col_types 
+  )
+  # for good result
+  expect_equal(
+    sapply(children(161994, 'itis')[['161994']], class), 
+    itis_expected_col_types 
+  )
+})
+
 test_that("rows parameter, when used, works", {
   skip_on_cran()
 

--- a/tests/testthat/test-col_children.R
+++ b/tests/testthat/test-col_children.R
@@ -28,5 +28,6 @@ test_that("missing/wrong data given returns result", {
 
   expect_equal(nrow(col_children(name="")[[1]]), 0)
   expect_equal(nrow(col_children(name="asdfasdfdf")[[1]]), 0)
+  expect_equal(unname(sapply(col_children(name="asdfasdfdf")[[1]], class)), rep('character', 3))
   expect_is(col_children(), "list")
 })

--- a/tests/testthat/test-ncbi_children.R
+++ b/tests/testthat/test-ncbi_children.R
@@ -17,4 +17,9 @@ test_that("ncbi_children returns correct class and result", {
   expect_is(tt2[[1]], "character")
   expect_error(ncbi_children(name = 'Ilex', id = 4751))
   expect_equal(ncbi_children(name = NA)[[1]], NA)
+
+  expect_equal(
+    unname(sapply(ncbi_children('dragon', db='ncbi')[[1]], class)),
+    c('character', 'character', 'character')
+  )
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

For the NCBI, COL, and ITIS databases, results that return no values now all have the same types as those that do return values.

I've also added tests.

The worms database is still not consistent:

```R
> children(get_wormsid("asdfasdfasdf"), 'worms')
$<NA>
[1] NA
```

## Related Issue

Fix #648 

## Example

``` R
> children('dragon', 'ncbi')
$dragon
[1] childtaxa_id   childtaxa_name childtaxa_rank
<0 rows> (or 0-length row.names)

attr(,"class")
[1] "children"
attr(,"db")
[1] "ncbi"

> children(1234123412, 'itis')
$`1234123412`
[1] parentname parenttsn  rankname   taxonname  tsn
<0 rows> (or 0-length row.names)

attr(,"class")
[1] "children"
attr(,"db")
[1] "itis"
```
