### PR TITLE
Fix #650 - allow integers in children(db="worms")

### DIFF
--- a/R/children.R
+++ b/R/children.R
@@ -149,7 +149,7 @@ set_output_types <- function(x, x_names, db){
 process_children_ids <- function(input, db, fxn, ...){
   g <- tryCatch(as.numeric(as.character(input)), warning = function(e) e)
   if (is(g, "numeric") || is.character(input) && grepl("[[:digit:]]", input)) {
-    as_fxn <- switch(db, itis = as.tsn, col = as.colid)
+    as_fxn <- switch(db, itis = as.tsn, col = as.colid, worms = as.wormsid)
     as_fxn(input, check = FALSE)
   } else {
     eval(fxn)(input, ...)

--- a/tests/testthat/test-children.R
+++ b/tests/testthat/test-children.R
@@ -16,6 +16,13 @@ test_that("passing in an id works", {
   skip_on_cran()
 
   ch_ncbi <- children(8028, db = 'ncbi')
+  ch_worms <- children(254966, db='worms')
+
+  expect_is(ch_worms, "children")
+  expect_equal(attr(ch_worms, "db"), "worms")
+  expect_named(ch_worms, '254966')
+  expect_is(ch_worms$`254966`, "data.frame")
+  expect_named(ch_worms$`254966`, c('childtaxa_id', 'childtaxa_name', 'childtaxa_rank'))
 
   expect_is(ch_ncbi, "children")
   expect_equal(attr(ch_ncbi, "db"), "ncbi")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allows integer ids to be passed to `children(x, db='worms')`. I've also added tests.

## Related

Fix #650
