### PR TITLE
Pass ... to ncbi_children from downsteam (see #653)

### DIFF
--- a/R/ncbi_downstream.R
+++ b/R/ncbi_downstream.R
@@ -26,6 +26,9 @@
 #' ## get intermediate taxa as a separate object
 #' ncbi_downstream(id = 7459, downto="species", intermediate = TRUE)
 #'
+#' ## get intermediate taxa as a separate object
+#' ncbi_downstream(id = 7459, downto="species", intermediate = TRUE)
+#'
 #' ## Lepidoptera
 #' ncbi_downstream(id = 7088, downto="superfamily")
 #'
@@ -51,7 +54,7 @@ ncbi_downstream <- function(id, downto, intermediate = FALSE, ...) {
   iter <- 0
   while (stop_ == "not") {
     iter <- iter + 1
-    tt <- dt2df(lapply(id, function(x) ncbi_children(id = x)[[1]]))
+    tt <- dt2df(lapply(id, function(x) ncbi_children(id = x, ...)[[1]]))
     tt$.id <- NULL
     tt <- rename(tt, c('childtaxa_rank' = 'rank'))
     tt <- prune_too_low(tt, downto, ignore_no_rank = TRUE)

--- a/man/ncbi_downstream.Rd
+++ b/man/ncbi_downstream.Rd
@@ -44,6 +44,9 @@ ncbi_downstream(id = 7459, downto="species")
 ## get intermediate taxa as a separate object
 ncbi_downstream(id = 7459, downto="species", intermediate = TRUE)
 
+## get intermediate taxa as a separate object
+ncbi_downstream(id = 7459, downto="species", intermediate = TRUE)
+
 ## Lepidoptera
 ncbi_downstream(id = 7088, downto="superfamily")
 


### PR DESCRIPTION
## Description

Pass ... to ncbi_children. This partially fixes #653, by allowing `ambiguous=TRUE` to be passed to `ncbi_children`, but does not distinguish between ambiguous nodes and species.

## Related Issue

Partial fix of #653 

## Example

```R
ncbi_downstream(id = 3700, downto="genus", ambiguous=TRUE)
```