### PR TITLE
Made NCBI fxns work if no API key is used

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Interacts with a suite of web 'APIs' for taxonomic tasks,
     species names, getting taxonomic hierarchies, fetching downstream and
     upstream taxonomic names, getting taxonomic synonyms, converting
     scientific to common names and vice versa, and more.
-Version: 0.9.2.9421
+Version: 0.9.2.9422
 License: MIT + file LICENSE
 URL: https://github.com/ropensci/taxize
 BugReports: https://github.com/ropensci/taxize/issues

--- a/R/classification.R
+++ b/R/classification.R
@@ -325,7 +325,10 @@ classification.uid <- function(id, callopts = list(), return_id = TRUE, ...) {
     if (is.na(x)) {
       out <- NA
     } else {
-      query <- list(db = "taxonomy", ID = x, api_key = key)
+      query <- list(db = "taxonomy", ID = x)
+      if (!is.null(key) && nzchar(key)) {
+        query <- c(query, list(api_key = key))
+      }
       cli <- crul::HttpClient$new(url = ncbi_base(), opts = callopts)
       res <- cli$get("entrez/eutils/efetch.fcgi", query = query)
       res$raise_for_status()

--- a/R/genbank2uid.R
+++ b/R/genbank2uid.R
@@ -41,8 +41,10 @@ genbank2uid <- function(id, batch_size = 100, key = NULL, ...) {
     key <- getkey(key, "ENTREZ_KEY")
     
     # Make NCBI eutils query
-    query <- tc(list(db = "nucleotide", id = paste(id, collapse = ","),
-      api_key = key))
+    query <- tc(list(db = "nucleotide", id = paste(id, collapse = ",")))
+    if (!is.null(key) && nzchar(key)) {
+      query <- c(query, list(api_key = key))
+    }
     
     # Execute query
     cli <- crul::HttpClient$new(url = ncbi_base(), opts = list(...))

--- a/R/ncbi_children.R
+++ b/R/ncbi_children.R
@@ -105,9 +105,11 @@ ncbi_children <- function(name = NULL, id = NULL, start = 0, max_return = 1000,
         db = 'taxonomy', 
         term = paste0(name, "[Next+Level]", ancestor_query),
         RetMax = max_return,
-        RetStart = start,
-        api_key = key
+        RetStart = start
       )
+      if (!is.null(key) && nzchar(key)) {
+        args <- c(args, list(api_key = key))
+      }
       args$term <- gsub("\\+", " ", args$term)
       
       # Search ncbi for children - - - - - - - - - - - - - - - - - - - - - - - 
@@ -127,9 +129,11 @@ ncbi_children <- function(name = NULL, id = NULL, start = 0, max_return = 1000,
         id = id,
         term = paste0(name, "[Next+Level]"),
         RetMax = max_return,
-        RetStart = start,
-        api_key = key
+        RetStart = start
       )
+      if (!is.null(key) && nzchar(key)) {
+        args <- c(args, list(api_key = key))
+      }
       args$term <- gsub("\\+", " ", args$term)
       
       # Search ncbi for children - - - - - - - - - - - - - - - - - - - - - - - 

--- a/R/ncbi_get_taxon_summary.R
+++ b/R/ncbi_get_taxon_summary.R
@@ -40,8 +40,10 @@ ncbi_get_taxon_summary <- function(id, key = NULL, ...) {
   }
   # Make eutils esummary query ------------------------------------------------
   key <- getkey(key, "ENTREZ_KEY")
-  query <- tc(list(db = "taxonomy", id = paste(id, collapse = "+"), 
-    api_key = key))
+  query <- tc(list(db = "taxonomy", id = paste(id, collapse = "+")))
+  if (!is.null(key) && nzchar(key)) {
+    query <- c(query, list(api_key = key))
+  }
   # Search ncbi taxonomy for uid ----------------------------------------------
   cli <- crul::HttpClient$new(url = ncbi_base(), opts = list(...))
   rr <- cli$get("entrez/eutils/esummary.fcgi", query = query)

--- a/R/sci2comm.R
+++ b/R/sci2comm.R
@@ -172,7 +172,10 @@ itis_foo <- function(x, simplify=TRUE, ...){
 
 ncbi_foo <- function(x, ...){
   key <- getkey(NULL, "ENTREZ_KEY")
-  query <- list(db = "taxonomy", ID = x, api_key = key)
+  query <- list(db = "taxonomy", ID = x)
+  if (!is.null(key) && nzchar(key)) {
+    query <- c(query, list(api_key = key))
+  }
   cli <- crul::HttpClient$new(url = ncbi_base(), opts = list(...))
   res <- cli$get("entrez/eutils/efetch.fcgi", query = query)
   res$raise_for_status()

--- a/tests/testthat/test-iucn_id.R
+++ b/tests/testthat/test-iucn_id.R
@@ -3,6 +3,9 @@ context("iucn_id")
 
 test_that("iucn_id returns the correct class", {
   skip_on_cran()
+  if (is.na(getkey(NA, service = "iucn"))) {
+    skip("No IUCN api key so test not run.")
+  }
 
   aa <- iucn_id("Branta canadensis")
   bb <- iucn_id("Panthera uncia")
@@ -19,7 +22,10 @@ test_that("iucn_id returns the correct class", {
 
 test_that("iucn_id fails well", {
   skip_on_cran()
-
+  if (is.na(getkey(NA, service = "iucn"))) {
+    skip("No IUCN api key so test not run.")
+  }
+  
   expect_error(iucn_id(), "argument \"sciname\" is missing")
   expect_equal(suppressWarnings(iucn_id("foo bar")), NA)
 })

--- a/tests/testthat/test-iucn_summary.R
+++ b/tests/testthat/test-iucn_summary.R
@@ -3,7 +3,10 @@ context("iucn_summary")
 
 test_that("iucn_summary returns the correct value", {
   skip_on_cran()
-
+  if (is.na(getkey(NA, service = "iucn"))) {
+    skip("No IUCN api key so test not run.")
+  }
+  
   temp <- iucn_summary(c("Panthera uncia", "Lynx lynx"))
   temp2 <- suppressWarnings(iucn_summary_id(c(22732, 12519)))
 
@@ -18,7 +21,10 @@ test_that("iucn_summary returns the correct value", {
 
 test_that("iucn_summary gives expected result for lots of names", {
   skip_on_cran()
-
+  if (is.na(getkey(NA, service = "iucn"))) {
+    skip("No IUCN api key so test not run.")
+  }
+  
   aa <- iucn_summary("Abies koreana")
   expect_equal(aa$`Abies koreana`$status, "EN")
 
@@ -46,7 +52,10 @@ test_that("iucn_summary gives expected result for lots of names", {
 
 test_that("iucn_summary_id with distr_detail produces correct output", {
   skip_on_cran()
-
+  if (is.na(getkey(NA, service = "iucn"))) {
+    skip("No IUCN api key so test not run.")
+  }
+  
   ii <- suppressWarnings(iucn_summary_id(22685566, distr_detail = TRUE))
   expect_equal(names(ii$`22685566`$distr), c("Native", "Introduced"))
   expect_equal(vapply(ii$`22685566`$distr, length, 0),
@@ -55,7 +64,10 @@ test_that("iucn_summary_id with distr_detail produces correct output", {
 
 test_that("iucn_summary and iucn_summary_id fail well", {
   skip_on_cran()
-
+  if (is.na(getkey(NA, service = "iucn"))) {
+    skip("No IUCN api key so test not run.")
+  }
+  
   expect_error(iucn_summary(""), "Not Found")
   #expect_equal(suppressWarnings(iucn_summary(""))[[1]]$status, NA)
   expect_warning(iucn_summary("Abies"), "not found")


### PR DESCRIPTION

## Description

When there is no API key for NCBI set, the queries to entrez ended up getting a "api_key=", which threw an invalid api error. Leaving the "api_key" arg out when there is no api fixed this.

## Related Issue

Fixes: 

https://github.com/ropensci/taxa/issues/135

## Tests

I fixed all failing tests that looked like they had something to do with a missing API key, but there are still ~5 tests that seem to be failing for other reasons.
I also made the IUCN tests be skipped if there is no API key.
