### PR TITLE
fixed `as.uid` error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Interacts with a suite of web 'APIs' for taxonomic tasks,
     species names, getting taxonomic hierarchies, fetching downstream and
     upstream taxonomic names, getting taxonomic synonyms, converting
     scientific to common names and vice versa, and more.
-Version: 0.9.3.9210
+Version: 0.9.3.9211
 License: MIT + file LICENSE
 URL: https://github.com/ropensci/taxize
 BugReports: https://github.com/ropensci/taxize/issues

--- a/R/classification.R
+++ b/R/classification.R
@@ -325,10 +325,7 @@ classification.uid <- function(id, callopts = list(), return_id = TRUE, ...) {
     if (is.na(x)) {
       out <- NA
     } else {
-      query <- list(db = "taxonomy", ID = x)
-      if (!is.null(key) && nzchar(key)) {
-        query <- c(query, list(api_key = key))
-      }
+      query <- tc(list(db = "taxonomy", ID = x, api_key = key))
       cli <- crul::HttpClient$new(url = ncbi_base(), opts = callopts)
       res <- cli$get("entrez/eutils/efetch.fcgi", query = query)
       res$raise_for_status()
@@ -356,7 +353,7 @@ classification.uid <- function(id, callopts = list(), return_id = TRUE, ...) {
       }
     }
     # NCBI limits requests to three per second
-    if (is.null(key) || !nzchar(key)) Sys.sleep(0.34)
+    if (is.null(key)) Sys.sleep(0.34)
     return(out)
   }
   out <- lapply(id, fun, callopts = callopts)

--- a/R/comm2sci.R
+++ b/R/comm2sci.R
@@ -133,7 +133,7 @@ c2s_itis_ <- function(x, by='search', simplify, ...){
 
 c2s_ncbi <- function(x, simplify, ...) {
   key <- getkey(NULL, "ENTREZ_KEY")
-  query <- list(db = "taxonomy", ID = x, api_key = key)
+  query <- tc(list(db = "taxonomy", ID = x, api_key = key))
   cli <- crul::HttpClient$new(url = ncbi_base(), opts = list(...))
   res <- cli$get("entrez/eutils/efetch.fcgi", query = query)
   res$raise_for_status()
@@ -142,7 +142,7 @@ c2s_ncbi <- function(x, simplify, ...) {
   # common name
   out <- xml_text(xml_find_all(ttp, "//TaxaSet/Taxon/ScientificName"))
   # NCBI limits requests to three per second
-  if (is.null(key) || !nzchar(key)) Sys.sleep(0.33)
+  if (is.null(key)) Sys.sleep(0.34)
   return(out)
 }
 

--- a/R/genbank2uid.R
+++ b/R/genbank2uid.R
@@ -41,11 +41,8 @@ genbank2uid <- function(id, batch_size = 100, key = NULL, ...) {
     key <- getkey(key, "ENTREZ_KEY")
     
     # Make NCBI eutils query
-    query <- tc(list(db = "nucleotide", id = paste(id, collapse = ",")))
-    if (!is.null(key) && nzchar(key)) {
-      query <- c(query, list(api_key = key))
-    }
-    
+    query <- tc(list(db = "nucleotide", id = paste(id, collapse = ","), api_key = key))
+
     # Execute query
     cli <- crul::HttpClient$new(url = ncbi_base(), opts = list(...))
     res <- cli$get("entrez/eutils/esummary.fcgi", query = query)
@@ -83,7 +80,7 @@ genbank2uid <- function(id, batch_size = 100, key = NULL, ...) {
     result <- data.frame(id = taxon_ids, name = titles,
                          stringsAsFactors = FALSE)
     # NCBI limits requests to three per second when no key
-    if (is.null(key) || !nzchar(key)) Sys.sleep(0.33)
+    if (is.null(key)) Sys.sleep(0.33)
     return(result)
   }
   # Run each batch and combine

--- a/R/get_uid.R
+++ b/R/get_uid.R
@@ -172,11 +172,7 @@ get_uid <- function(sciname, ask = TRUE, messages = TRUE, rows = NA,
     term <- sciname
     if (!is.null(rank_query)) term <- paste0(term, sprintf(" AND %s[Rank]", rank_query))
     try_again_errors <- c("Could not resolve host: eutils.ncbi.nlm.nih.gov")
-    query_args <- list(db = "taxonomy", 
-                       term = term)
-    if (!is.null(key) && nzchar(key)) {
-      query_args <- c(query_args, list(api_key = key))
-    }
+    query_args <- tc(list(db = "taxonomy", term = term, api_key = key))
     raw_xml_result <- repeat_until_it_works(try_again_errors,
                                             "esearch", 
                                             query = query_args,
@@ -184,7 +180,7 @@ get_uid <- function(sciname, ask = TRUE, messages = TRUE, rows = NA,
     xml_result <- xml2::read_xml(raw_xml_result)
 
     # NCBI limits requests to three per second when no key 
-    if (is.null(key) || !nzchar(key)) Sys.sleep(0.33)
+    if (is.null(key)) Sys.sleep(0.33)
     uid <- xml2::xml_text(xml2::xml_find_all(xml_result, "//IdList/Id"))
     mm <- length(uid) > 1
 
@@ -204,10 +200,7 @@ get_uid <- function(sciname, ask = TRUE, messages = TRUE, rows = NA,
     if (length(uid) > 1) {
       ID <- paste(uid, collapse = ",")
       try_again_errors <- c("Could not resolve host: eutils.ncbi.nlm.nih.gov")
-      query_args <- list(db = "taxonomy", ID = ID)
-      if (!is.null(key) && nzchar(key)) {
-        query_args <- c(query_args, list(api_key = key))
-      }
+      query_args <- tc(list(db = "taxonomy", ID = ID, api_key = key))
       tt <- repeat_until_it_works(try_again_errors, "esummary", 
                                   query_args, ...)
       ttp <- xml2::read_xml(tt)
@@ -351,10 +344,7 @@ make_uid <- function(x, check=TRUE) {
 check_uid <- function(x){
   key <- getkey(NULL, "ENTREZ_KEY")
   cli <- crul::HttpClient$new(url = ncbi_base())
-  args <- list(db = "taxonomy", id = x)
-  if (!is.null(key) && nzchar(key)) {
-    args <- c(args, list(api_key = key))
-  }
+  args <- tc(list(db = "taxonomy", id = x, api_key = key))
   res <- cli$get("entrez/eutils/esummary.fcgi", query = args)
   res$raise_for_status()
   tt <- xml2::read_xml(res$parse("UTF-8"))

--- a/R/get_uid.R
+++ b/R/get_uid.R
@@ -351,8 +351,11 @@ make_uid <- function(x, check=TRUE) {
 check_uid <- function(x){
   key <- getkey(NULL, "ENTREZ_KEY")
   cli <- crul::HttpClient$new(url = ncbi_base())
-  res <- cli$get("entrez/eutils/esummary.fcgi", 
-    query = list(db = "taxonomy", id = x, api_key = key))
+  args <- list(db = "taxonomy", id = x)
+  if (!is.null(key) && nzchar(key)) {
+    args <- c(args, list(api_key = key))
+  }
+  res <- cli$get("entrez/eutils/esummary.fcgi", query = args)
   res$raise_for_status()
   tt <- xml2::read_xml(res$parse("UTF-8"))
   tryid <- xml2::xml_text(xml2::xml_find_all(tt, "//Id"))

--- a/R/getkey.R
+++ b/R/getkey.R
@@ -78,8 +78,10 @@ getkey <- function(x = NULL, service) {
     if (service == "ENTREZ_KEY") {
       if (is.null(key) || !nzchar(key)) {
         message("No ENTREZ API key provided\nSee https://ncbiinsights.ncbi.nlm.nih.gov/2017/11/02/new-api-keys-for-the-e-utilities/")
+        return(NULL)
+      } else {
+        return(key)
       }
-      return(key)
     }
 
     # if IUCN, stop if no key as a key is required

--- a/R/ncbi_children.R
+++ b/R/ncbi_children.R
@@ -101,15 +101,13 @@ ncbi_children <- function(name = NULL, id = NULL, start = 0, max_return = 1000,
     }
     
     if (is.null(id)) {
-      args <- list(
+      args <- tc(list(
         db = 'taxonomy', 
         term = paste0(name, "[Next+Level]", ancestor_query),
         RetMax = max_return,
-        RetStart = start
-      )
-      if (!is.null(key) && nzchar(key)) {
-        args <- c(args, list(api_key = key))
-      }
+        RetStart = start,
+        api_key = key
+      ))
       args$term <- gsub("\\+", " ", args$term)
       
       # Search ncbi for children - - - - - - - - - - - - - - - - - - - - - - - 
@@ -123,17 +121,15 @@ ncbi_children <- function(name = NULL, id = NULL, start = 0, max_return = 1000,
       children_uid <- xml_text_all(results, "//eSearchResult/IdList/Id")
       
     } else {
-      args <- list(
+      args <- tc(list(
         dbfrom = 'taxonomy',
         db = 'taxonomy',
         id = id,
         term = paste0(name, "[Next+Level]"),
         RetMax = max_return,
-        RetStart = start
-      )
-      if (!is.null(key) && nzchar(key)) {
-        args <- c(args, list(api_key = key))
-      }
+        RetStart = start,
+        api_key = key
+      ))
       args$term <- gsub("\\+", " ", args$term)
       
       # Search ncbi for children - - - - - - - - - - - - - - - - - - - - - - - 
@@ -174,7 +170,7 @@ ncbi_children <- function(name = NULL, id = NULL, start = 0, max_return = 1000,
       rownames(output) <- NULL 
     }
     # NCBI limits requests to three per second
-    if (is.null(key) || !nzchar(key)) Sys.sleep(0.34)
+    if (is.null(key)) Sys.sleep(0.34)
     return(output)
   }
   # Combine the result of multiple searches -----------------------------------

--- a/R/ncbi_get_taxon_summary.R
+++ b/R/ncbi_get_taxon_summary.R
@@ -40,10 +40,7 @@ ncbi_get_taxon_summary <- function(id, key = NULL, ...) {
   }
   # Make eutils esummary query ------------------------------------------------
   key <- getkey(key, "ENTREZ_KEY")
-  query <- tc(list(db = "taxonomy", id = paste(id, collapse = "+")))
-  if (!is.null(key) && nzchar(key)) {
-    query <- c(query, list(api_key = key))
-  }
+  query <- tc(list(db = "taxonomy", id = paste(id, collapse = "+"), api_key = key))
   # Search ncbi taxonomy for uid ----------------------------------------------
   cli <- crul::HttpClient$new(url = ncbi_base(), opts = list(...))
   rr <- cli$get("entrez/eutils/esummary.fcgi", query = query)
@@ -59,6 +56,6 @@ ncbi_get_taxon_summary <- function(id, key = NULL, ...) {
   )
   output$rank[output$rank == ''] <- "no rank"
   # NCBI limits requests to three per second
-  if (is.null(key) || !nzchar(key)) Sys.sleep(0.33)
+  if (is.null(key)) Sys.sleep(0.33)
   return(output)
 }

--- a/R/sci2comm.R
+++ b/R/sci2comm.R
@@ -172,10 +172,7 @@ itis_foo <- function(x, simplify=TRUE, ...){
 
 ncbi_foo <- function(x, ...){
   key <- getkey(NULL, "ENTREZ_KEY")
-  query <- list(db = "taxonomy", ID = x)
-  if (!is.null(key) && nzchar(key)) {
-    query <- c(query, list(api_key = key))
-  }
+  query <- tc(list(db = "taxonomy", ID = x, api_key = key))
   cli <- crul::HttpClient$new(url = ncbi_base(), opts = list(...))
   res <- cli$get("entrez/eutils/efetch.fcgi", query = query)
   res$raise_for_status()
@@ -186,7 +183,7 @@ ncbi_foo <- function(x, ...){
     xml_find_all(ttp,
       "//TaxaSet/Taxon/OtherNames/GenbankCommonName"))
   # NCBI limits requests to three per second
-  if (is.null(key) || !nzchar(key)) Sys.sleep(0.33)
+  if (is.null(key)) Sys.sleep(0.33)
   return(out)
 }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Uses the same method as my last PR. Still need to change to the `tt` with an API key default of `NULL` version, but this works for now at least. 

## Related Issue

resolves #674

## Example

```r
> as.uid(315567)
No ENTREZ API key provided
See https://ncbiinsights.ncbi.nlm.nih.gov/2017/11/02/new-api-keys-for-the-e-utilities/
[1] "315567"
attr(,"class")
[1] "uid"
attr(,"match")
[1] "found"
attr(,"multiple_matches")
[1] FALSE
attr(,"pattern_match")
[1] FALSE
attr(,"uri")
[1] "https://www.ncbi.nlm.nih.gov/taxonomy/315567"
```