### PR TITLE
Fix class2tree bug

### DIFF
--- a/R/class2tree.R
+++ b/R/class2tree.R
@@ -330,7 +330,8 @@ taxonomy_table_creator <- function(nameList,rankList){
 
     ### subselect mTaxonDf to keep only 2 column rank id and rank name
     mTaxonDf <- mTaxonDf[,c("X1","X2")]
-    if(mTaxonDf$X2[1] != index2RankDf$rank[1]){
+    if(mTaxonDf$X2[1] != index2RankDf$rank[1] &&
+       !index2RankDf$rank[1] %in% mTaxonDf$X2){
       mTaxonDf <- rbind(data.frame("X1"=mTaxonDf$X1[1],
                                    "X2"=index2RankDf$rank[1]),
                                    mTaxonDf)

--- a/tests/testthat/test-class2tree.R
+++ b/tests/testthat/test-class2tree.R
@@ -6,7 +6,7 @@ spnames <- c('Klattia flava', 'Trollius sibiricus', 'Arachis paraguariensis',
  'Pilea verrucosa','Tibouchina striphnocalyx','Lycium dasystemum',
  'Berkheya echinacea','Androcymbium villosum',
  'Helianthus annuus','Madia elegans','Lupinus albicaulis',
- 'Pinus lambertiana')
+ 'Pinus lambertiana', "Haloarcula amylolytica JCM 13557")
 
 dupnames <- c('Mus musculus', 'Escherichia coli',
               'Haloferax denitrificans','Mus musculus')
@@ -26,6 +26,8 @@ test_that("class2tree returns the correct value and class", {
   expect_is(tr$classification, "data.frame")
   expect_is(tr$distmat, "dist")
   expect_is(tr$names, "character")
+  
+  expect_equal(anyDuplicated(gsub("\\.\\d+$", "", names(tr$classification))), 0)
 })
 
 test_that("class2tree will abort when input contains duplicate taxa", {


### PR DESCRIPTION
organisms with unique rank lower than non-unique ranks will give extra wrong rows in 'taxonomy_table_creator' function

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Check existence of the lowest non-unique rank (i.e. 'species') before rbind

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
fix #689

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
```
library(taxize)
library(taxizedb)
organisms = c("Haloarcula amylolytica JCM 13557",
              "Haloarcula argentinensis DSM 12282",
              "Haloarcula californiae ATCC 33799",
              "Halarchaeum acidiphilum MH1-52-1")
taxon_IDs = name2taxid(organisms)
taxon_IDs
## [1] "1227452" "1230451" "662475"  "1261545"

classes = taxizedb::classification(taxon_IDs, db = "ncbi")
tr = class2tree(classes)
tr$classification
##                                                     species       genus
## Haloarcula amylolytica JCM 13557     Haloarcula amylolytica  Haloarcula
## Haloarcula argentinensis DSM 12282 Haloarcula argentinensis  Haloarcula
## Haloarcula californiae ATCC 33799    Haloarcula californiae  Haloarcula
## Halarchaeum acidiphilum MH1-52-1    Halarchaeum acidiphilum Halarchaeum
##                                              family           order        class
## Haloarcula amylolytica JCM 13557     Haloarculaceae Halobacteriales Halobacteria
## Haloarcula argentinensis DSM 12282   Haloarculaceae Halobacteriales Halobacteria
## Haloarcula californiae ATCC 33799    Haloarculaceae Halobacteriales Halobacteria
## Halarchaeum acidiphilum MH1-52-1   Halobacteriaceae Halobacteriales Halobacteria
##                                           phylum superkingdom      norank_131567
## Haloarcula amylolytica JCM 13557   Euryarchaeota      Archaea cellular organisms
## Haloarcula argentinensis DSM 12282 Euryarchaeota      Archaea cellular organisms
## Haloarcula californiae ATCC 33799  Euryarchaeota      Archaea cellular organisms
## Halarchaeum acidiphilum MH1-52-1   Euryarchaeota      Archaea cellular organisms
```
<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
