### PR TITLE
Fix taxon names with '#'

### DIFF
--- a/R/class2tree.R
+++ b/R/class2tree.R
@@ -204,7 +204,7 @@ get_name <- function(x){
   joinedDf <- within(joinedDf,
                      rankDf[rankDf=='no rank'] <-
                      paste0("norank_",idDf[rankDf=='no rank']))
-  joinedDf$name <- paste0(joinedDf$nameDf,"#",joinedDf$rankDf)
+  joinedDf$name <- paste0(joinedDf$nameDf,"##",joinedDf$rankDf)
 
   df <- data.frame(t(data.frame(rev(joinedDf$name))), stringsAsFactors = FALSE)
   outDf <- data.frame(tip = x[nrow(x), "name"], df, stringsAsFactors = FALSE)
@@ -312,7 +312,7 @@ taxonomy_table_creator <- function(nameList,rankList){
     ### get list of all IDs for this taxon
     taxonDf <- data.frame(nameList[i,])
     taxonName <- unlist(strsplit(as.character(nameList[i,]$tip),
-                                "#",
+                                "##",
                                 fixed = TRUE))
 
     ### convert into long format
@@ -321,7 +321,7 @@ taxonomy_table_creator <- function(nameList,rankList){
     ### get rank names and corresponding IDs
     splitCol <- data.frame(do.call('rbind',
                                    strsplit(as.character(mTaxonDf$value),
-                                   '#',
+                                   "##",
                                    fixed=TRUE)))
     mTaxonDf <- cbind(mTaxonDf,splitCol)
 

--- a/tests/testthat/test-class2tree.R
+++ b/tests/testthat/test-class2tree.R
@@ -6,7 +6,8 @@ spnames <- c('Klattia flava', 'Trollius sibiricus', 'Arachis paraguariensis',
  'Pilea verrucosa','Tibouchina striphnocalyx','Lycium dasystemum',
  'Berkheya echinacea','Androcymbium villosum',
  'Helianthus annuus','Madia elegans','Lupinus albicaulis',
- 'Pinus lambertiana', "Haloarcula amylolytica JCM 13557")
+ 'Pinus lambertiana', "Haloarcula amylolytica JCM 13557",
+ "Halomonas sp. 'Soap Lake #6'")
 
 dupnames <- c('Mus musculus', 'Escherichia coli',
               'Haloferax denitrificans','Mus musculus')


### PR DESCRIPTION
Fix wrong split output when taxon names contain '#'

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Found that scientific names in NCBI contain one single '#' at most, so replacing '#' with '##' may solve it. 

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
Fix #699 

