### PR TITLE
bug fix for get_eolid function

### DIFF
--- a/R/get_eolid.R
+++ b/R/get_eolid.R
@@ -98,11 +98,11 @@ get_eolid <- function(sciname, ask = TRUE, messages = TRUE, key = NULL,
 
   assert(ask, "logical")
   assert(messages, "logical")
+
   fun <- function(sciname, ask, messages, rows, ...) {
     direct <- FALSE
     mssg(messages, "\nRetrieving data for taxon '", sciname, "'\n")
     tmp <- eol_search(terms = sciname, key = key, ...)
-
     ms <- "Not found. Consider checking the spelling or alternate classification"
     datasource <- NA_character_
     if (all(is.na(tmp))) {
@@ -152,6 +152,7 @@ get_eolid <- function(sciname, ask = TRUE, messages = TRUE, key = NULL,
       mssg(messages, ms)
       id <- NA_character_
       page_id <- NA_character_
+			mm <- FALSE
       att <- 'not found'
     }
     # only one found on eol


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Simple one line change to address issue #701 

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
#701 


## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

### Old version
`get_eolid('Helianthus annuus texanus')`

```
> Retrieving data for taxon 'Helianthus annuus texanus'
> Not found. Consider checking the spelling or alternate classification
> Did find: Helianthus annuus subsp. texanus; Helianthus annuus subsp. texanus; Helianthus annuus L.
> Not found. Consider checking the spelling or alternate classification
> Error in FUN(X[[i]], ...) : object 'mm' not found
```


### PR version

```
> Retrieving data for taxon 'Helianthus annuus texanus'
> Not found. Consider checking the spelling or alternate classification
> Did find: Helianthus annuus subsp. texanus; Helianthus annuus subsp. texanus; Helianthus annuus L.
> Not found. Consider checking the spelling or alternate classification
```


