### PR TITLE
Fix get_tolid rbindlist bug

### DIFF
--- a/R/get_tolid.R
+++ b/R/get_tolid.R
@@ -280,6 +280,10 @@ tol_fetch_fuzzy <- function(x) {
 }
 
 dtrbsetdf <- function(x) {
+  x <- lapply(x, function(a) {
+    a[sapply(a, is.null)] <- NA
+    a
+  })
   (out <- data.table::setDF(
     data.table::rbindlist(x, use.names = TRUE, fill = TRUE)
   ))


### PR DESCRIPTION
Fix data.table::rbindlist error: Unsupported type 'NULL'

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Substitute NULL with NA to fix the problem.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
fix #710 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

```r
get_tolid("Acanthamoeba castellanii str. Neff")
# 
# Retrieving data for taxon 'Acanthamoeba castellanii str. Neff'
# 
# [1] "381936"
# attr(,"match")
# [1] "found"
# attr(,"multiple_matches")
# [1] FALSE
# attr(,"pattern_match")
# [1] FALSE
# attr(,"uri")
# [1] "https://tree.opentreeoflife.org/opentree/argus/ottol@381936"
# attr(,"class")
# [1] "tolid"
```