### PR TITLE
Add node labels for class2tree (issue #644)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -93,7 +93,8 @@ Imports:
     tibble (>= 1.2),
     worrms (>= 0.3.2),
     natserv (>= 0.3.0),
-    wikitaxa (>= 0.3.0)
+    wikitaxa (>= 0.3.0),
+    phangorn
 Suggests:
     testthat,
     knitr,

--- a/R/class2tree.R
+++ b/R/class2tree.R
@@ -90,7 +90,18 @@ class2tree <- function(input, varstep = TRUE, check = TRUE, ...) {
   # check for incorrect dimensions error
   if (is(taxdis, 'simpleError'))
     stop("Try check=FALSE, but see docs for taxa2dist function in the vegan package for details.")
+  
   out <- as.phylo.hclust(hclust(taxdis, ...))
+  # Add node labels
+  node_ids <- sort(unique(out$edge[,1]))
+  node_labels <- sapply(phangorn::Descendants(out, node_ids), function(x) {
+    sub_df <- df[out$tip.label[x],]
+    unique(sub_df[,which(sapply(1:ncol(sub_df), function(i) {
+      length(unique(sub_df[,i]))==1
+    }))[1]])
+  })
+  out$node.label <- node_labels
+  
   res <- list(phylo = out, classification = as.data.frame(t(tdf)), 
     distmat = taxdis, names = names(input))
   class(res) <- 'classtree'

--- a/R/class2tree.R
+++ b/R/class2tree.R
@@ -92,6 +92,7 @@ class2tree <- function(input, varstep = TRUE, check = TRUE, ...) {
     stop("Try check=FALSE, but see docs for taxa2dist function in the vegan package for details.")
   
   out <- as.phylo.hclust(hclust(taxdis, ...))
+  out <- ape::di2multi(out)
   # Add node labels
   node_ids <- sort(unique(out$edge[,1]))
   node_labels <- sapply(phangorn::Descendants(out, node_ids), function(x) {

--- a/R/class2tree.R
+++ b/R/class2tree.R
@@ -64,7 +64,6 @@ class2tree <- function(input, varstep = TRUE, check = TRUE, ...) {
   if (length(unique(names(input))) < length(names(input)))
     stop("Input list of classifications contains duplicates")
 
-  dat <- rbind.fill(lapply(input, class2tree_helper))
   # Get rank and ID list
   rankList <- rbind.fill(lapply(input, get_rank))
   nameList <- rbind.fill(lapply(input, get_name))
@@ -96,13 +95,6 @@ class2tree <- function(input, varstep = TRUE, check = TRUE, ...) {
     distmat = taxdis, names = names(input))
   class(res) <- 'classtree'
   return( res )
-}
-
-class2tree_helper <- function(x){
-  df <- x[-nrow(x), 'name']
-  names(df) <- x[-nrow(x), 'rank']
-  df <- data.frame(t(data.frame(df)), stringsAsFactors = FALSE)
-  data.frame(tip = x[nrow(x), "name"], df, stringsAsFactors = FALSE)
 }
 
 #' @method plot classtree

--- a/tests/testthat/test-class2tree.R
+++ b/tests/testthat/test-class2tree.R
@@ -27,6 +27,8 @@ test_that("class2tree returns the correct value and class", {
   expect_is(tr$classification, "data.frame")
   expect_is(tr$distmat, "dist")
   expect_is(tr$names, "character")
+  expect_is(tr$phylo$node.label, "character")
+  expect_equal(length(tr$phylo$node.label), tr$phylo$Nnode)
   expect_equal(
     anyDuplicated(gsub("\\.\\d+$", "", names(tr$classification))), 0)
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

## Description
<!--- Describe your changes in detail -->
1. Add node labels for class2tree
2. call `ape::di2multi` by default.
I wonder if there's a reason to keep a binary tree.
3. remove lines no longer needed.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
#644 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
```r
spnames <- c("Gallus gallus", "Homo sapiens", "Xenopus Silurana tropicalis",
             "Zea mays", "Bombyx mori", "Alexandrium minutum",
             "Alexandrium ostenfeldii", "Alexandrium tamarense")
out <- classification(spnames, db = "ncbi", verbose = FALSE)
out <- out[!is.na(out)]
tr <- class2tree(out)
plot(tr)
ape::nodelabels(tr$phylo$node.label)
```
<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
