### PR TITLE
Vegan fixes

### DIFF
--- a/R/rankagg.R
+++ b/R/rankagg.R
@@ -7,16 +7,16 @@
 #' @param rank Taxonomic rank to aggregate by (character)
 #' @param fxn Arithmetic function or vector or functions (character)
 #' @examples
-#' library("vegan")
-#' data(dune.taxon, package='vegan')
+#' if (require(vegan)) {
+#' data(dune.taxon, dune, package='vegan')
 #' dat <- dune.taxon
-#' set.seed(1234)
-#' dat$abundance <- round(rlnorm(n=nrow(dat),meanlog=5,sdlog=2),0)
+#' dat$abundance <- colSums(dune)
 #' rankagg(data=dat, datacol="abundance", rank="Genus")
 #' rankagg(data=dat, "abundance", rank="Family")
 #' rankagg(data=dat, "abundance", rank="Genus", fxn="mean")
 #' rankagg(data=dat, "abundance", rank="Subclass")
 #' rankagg(data=dat, "abundance", rank="Subclass", fxn="sd")
+#' }
 rankagg <- function(data=NULL, datacol=NULL, rank=NULL, fxn="sum") {
   if (is.null(data) | is.null(rank))
     stop("You must specify your data.frame and taxonomic rank")

--- a/R/tax_agg.R
+++ b/R/tax_agg.R
@@ -27,19 +27,18 @@
 #' @examples \dontrun{
 #' if (requireNamespace("vegan", quietly = TRUE)) {
 #'   # use dune dataset
-#'   library("vegan")
 #'   data(dune, package='vegan')
-#'   species <- c("Bellis perennis", "Empetrum nigrum", "Juncus bufonius",
-#'   "Juncus articulatus",
-#'   "Aira praecox", "Eleocharis parvula", "Rumex acetosa", "Vicia lathyroides",
-#'   "Brachythecium rutabulum", "Ranunculus flammula", "Cirsium arvense",
-#'   "Hypochaeris radicata", "Leontodon autumnalis", "Potentilla palustris",
-#'   "Poa pratensis", "Calliergonella cuspidata", "Trifolium pratense",
-#'   "Trifolium repens", "Anthoxanthum odoratum", "Salix repens", "Achillea
-#'   millefolium",
-#'   "Poa trivialis", "Chenopodium album", "Elymus repens", "Sagina procumbens",
-#'   "Plantago lanceolata", "Agrostis stolonifera", "Lolium perenne", "Alopecurus
-#'   geniculatus", "Bromus hordeaceus")
+#'   species <- c("Achillea millefolium", "Agrostis stolonifera",
+#'     "Aira praecox", "Alopecurus geniculatus", "Anthoxanthum odoratum",
+#'     "Bellis perennis", "Bromus hordeaceus", "Chenopodium album",
+#'     "Cirsium arvense", "Comarum palustre", "Eleocharis palustris",
+#'     "Elymus repens", "Empetrum nigrum", "Hypochaeris radicata",
+#'     "Juncus articulatus", "Juncus bufonius", "Lolium perenne",
+#'     "Plantago lanceolata", "Poa pratensis", "Poa trivialis",
+#'     "Ranunculus flammula", "Rumex acetosa", "Sagina procumbens",
+#'     "Salix repens", "Scorzoneroides autumnalis", "Trifolium pratense",
+#'     "Trifolium repens", "Vicia lathyroides", "Brachythecium rutabulum",
+#'     "Calliergonella cuspidata")
 #'   colnames(dune) <- species
 #'
 #'   # aggregate sample to families

--- a/man/rankagg.Rd
+++ b/man/rankagg.Rd
@@ -20,14 +20,14 @@ Genus, Tribe, etc.) (data.frame)}
 Aggregate data by given taxonomic rank
 }
 \examples{
-library("vegan")
-data(dune.taxon, package='vegan')
+if (require(vegan)) {
+data(dune.taxon, dune, package='vegan')
 dat <- dune.taxon
-set.seed(1234)
-dat$abundance <- round(rlnorm(n=nrow(dat),meanlog=5,sdlog=2),0)
+dat$abundance <- colSums(dune)
 rankagg(data=dat, datacol="abundance", rank="Genus")
 rankagg(data=dat, "abundance", rank="Family")
 rankagg(data=dat, "abundance", rank="Genus", fxn="mean")
 rankagg(data=dat, "abundance", rank="Subclass")
 rankagg(data=dat, "abundance", rank="Subclass", fxn="sd")
+}
 }

--- a/man/tax_agg.Rd
+++ b/man/tax_agg.Rd
@@ -46,19 +46,18 @@ is on higher taxonomic level this taxon is not aggregated.
 \dontrun{
 if (requireNamespace("vegan", quietly = TRUE)) {
   # use dune dataset
-  library("vegan")
   data(dune, package='vegan')
-  species <- c("Bellis perennis", "Empetrum nigrum", "Juncus bufonius",
-  "Juncus articulatus",
-  "Aira praecox", "Eleocharis parvula", "Rumex acetosa", "Vicia lathyroides",
-  "Brachythecium rutabulum", "Ranunculus flammula", "Cirsium arvense",
-  "Hypochaeris radicata", "Leontodon autumnalis", "Potentilla palustris",
-  "Poa pratensis", "Calliergonella cuspidata", "Trifolium pratense",
-  "Trifolium repens", "Anthoxanthum odoratum", "Salix repens", "Achillea
-  millefolium",
-  "Poa trivialis", "Chenopodium album", "Elymus repens", "Sagina procumbens",
-  "Plantago lanceolata", "Agrostis stolonifera", "Lolium perenne", "Alopecurus
-  geniculatus", "Bromus hordeaceus")
+  species <- c("Achillea millefolium", "Agrostis stolonifera",
+    "Aira praecox", "Alopecurus geniculatus", "Anthoxanthum odoratum",
+    "Bellis perennis", "Bromus hordeaceus", "Chenopodium album",
+    "Cirsium arvense", "Comarum palustre", "Eleocharis palustris",
+    "Elymus repens", "Empetrum nigrum", "Hypochaeris radicata",
+    "Juncus articulatus", "Juncus bufonius", "Lolium perenne",
+    "Plantago lanceolata", "Poa pratensis", "Poa trivialis",
+    "Ranunculus flammula", "Rumex acetosa", "Sagina procumbens",
+    "Salix repens", "Scorzoneroides autumnalis", "Trifolium pratense",
+    "Trifolium repens", "Vicia lathyroides", "Brachythecium rutabulum",
+    "Calliergonella cuspidata")
   colnames(dune) <- species
 
   # aggregate sample to families


### PR DESCRIPTION
This is a minor PR that fixes some usage of the `dune` data of the **vegan** package in examples:

- `rankagg`: running example is made conditional on the availability of **vegan**, and real abundance data are used instead of random data.
- `tax_agg`: fixes the species names (mainly their ordering) in the `dune` data.