### PR TITLE
fix outdated aou_notes.R

### DIFF
--- a/inst/ignore/aou_notes.R
+++ b/inst/ignore/aou_notes.R
@@ -1,8 +1,7 @@
-#  from http://www.birdpop.org/alphacodes.htm
-download.file("http://www.birdpop.org/docs/misc/List18.zip", destfile = "~/List18.zip")
-unzip("~/List18.zip", exdir = "~/")
-library(foreign)
-res <- foreign::read.dbf("~/List18.DBF", as.is = TRUE)
+#  from https://www.birdpop.org/pages/birdSpeciesCodes.php
+download.file("http://www.birdpop.org/docs/misc/IBPAOU.zip", destfile = "~/IBPAOU.zip")
+unzip("~/IBPAOU.zip", exdir = "~/")
+res <- read.csv("~/IBP-Alpha-Codes20.csv")
 head(res)
 
 # checklist from http://checklist.aou.org/taxa/


### PR DESCRIPTION
## Description
Minor edits, updating the `inst/ignore/aou_notes.R` helper file as the birdpop.org seems to have changed some links/filenames. No longer distributed as a DBF as well so this drops the need for `foreign`. 

## Related Issue
NA

## Example

``` r
#  from https://www.birdpop.org/pages/birdSpeciesCodes.php
download.file("http://www.birdpop.org/docs/misc/IBPAOU.zip", destfile = "~/IBPAOU.zip")
unzip("~/IBPAOU.zip", exdir = "~/")
res <- read.csv("~/IBP-Alpha-Codes20.csv")
head(res)
#>   SP SPEC CONF             COMMONNAME                  SCINAME  SPEC6 CONF6
#> 1    HITI            Highland Tinamou   Nothocercus bonapartei NOTBON      
#> 2    GRTI               Great Tinamou            Tinamus major TINMAJ      
#> 3    LITI              Little Tinamou        Crypturellus soui CRYSOU      
#> 4    THTI             Thicket Tinamou Crypturellus cinnamomeus CRYCIN      
#> 5    SBTI      Slaty-breasted Tinamou    Crypturellus boucardi CRYBOU      
#> 6    CHTI               Choco Tinamou     Crypturellus kerriae CRYKER

# checklist from http://checklist.aou.org/taxa/
chklst <- read.csv('http://checklist.aou.org/taxa.csv', header = TRUE, sep = ",", stringsAsFactors = FALSE)
head(chklst)
#>   id       avibase.id    rank            common_name          french_name
#> 1  2 66C31E09F8C285D6 species       Highland Tinamou Tinamou de Bonaparte
#> 2  1 42D72AE118D2DE82 species          Great Tinamou        Grand Tinamou
#> 3  3 39DD9DD76680A7F0 species         Little Tinamou         Tinamou soui
#> 4  4 AAB5CEED3FC9EDE1 species        Thicket Tinamou     Tinamou cannelle
#> 5  5 5183B60E14DE99FD species Slaty-breasted Tinamou   Tinamou de Boucard
#> 6  6 2ED97B5485B54942 species          Choco Tinamou      Tinamou de Kerr
#>          order    family subfamily        genus                  species
#> 1 Tinamiformes Tinamidae            Nothocercus   Nothocercus bonapartei
#> 2 Tinamiformes Tinamidae                Tinamus            Tinamus major
#> 3 Tinamiformes Tinamidae           Crypturellus        Crypturellus soui
#> 4 Tinamiformes Tinamidae           Crypturellus Crypturellus cinnamomeus
#> 5 Tinamiformes Tinamidae           Crypturellus    Crypturellus boucardi
#> 6 Tinamiformes Tinamidae           Crypturellus     Crypturellus kerriae
#>   annotation status_accidental status_hawaiian status_introduced
#> 1                                                               
#> 2                                                               
#> 3                                                               
#> 4                                                               
#> 5                                                               
#> 6 Monotypic.                                                    
#>   status_nonbreeding status_extinct status_misplaced
#> 1                                                   
#> 2                                                   
#> 3                                                   
#> 4                                                   
#> 5                                                   
#> 6

pryr::object_size(res)
#> Registered S3 method overwritten by 'pryr':
#>   method      from
#>   print.bytes Rcpp
#> 726 kB
pryr::object_size(chklst)
#> 1.04 MB
```

<sup>Created on 2020-11-11 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
