### PR TITLE
class2tree checks duplicated taxa in higher levels, resolve #934

### DIFF
--- a/R/class2tree.R
+++ b/R/class2tree.R
@@ -396,6 +396,35 @@ rank_indexing <- function (rankList) {
 #' @author Vinh Tran {tran@bio.uni-frankfurt.de}
 taxonomy_table_creator <- function (nameList, rankList) {
   colnames(nameList)[1] <- "tip"
+  # remove duplicated taxa (e.g. taxa with higher levels, that already belong 
+  # to the taxonomy string of other taxa)
+  duplicatedTaxa <- lapply(
+      nameList$X1,
+      function (x) {
+          matchs <-data.frame(which(nameList[,-1] == x, arr.ind=TRUE))
+          checkHigherRank <- lapply(
+              matchs$row,
+              function(y) {
+                  if (nameList[y,]$X1 != x) return(1)
+              }
+          )
+          if (length(unlist(checkHigherRank)) > 0) 
+              return(strsplit(x, "#", fixed = TRUE)[[1]][1])
+      }
+  )
+  if (length(unlist(duplicatedTaxa)) > 0) {
+      msg <- paste("WARNING:", length(unlist(duplicatedTaxa)))
+      msg <- "duplicated taxa have been ignored!"
+      if (length(unlist(duplicatedTaxa)) == 1)
+          msg <- "duplicated taxon has been ignored!"
+      if (length(unlist(duplicatedTaxa)) < 5) {
+          msg <- paste(msg, "Including: ")
+          msg <- c(msg, paste(unlist(duplicatedTaxa), collapse = "; "))
+      }   
+      message(msg)
+  }
+  nameList <- nameList[!(nameList$tip %in% unlist(duplicatedTaxa)),]
+  rankList <- rankList[!(rankList$tip %in% unlist(duplicatedTaxa)),]
   # get indexed rank list
   index2RankDf <- rank_indexing(rankList)
   # get ordered rank list

--- a/R/class2tree.R
+++ b/R/class2tree.R
@@ -414,9 +414,10 @@ taxonomy_table_creator <- function (nameList, rankList) {
   )
   if (length(unlist(duplicatedTaxa)) > 0) {
       msg <- paste("WARNING:", length(unlist(duplicatedTaxa)))
-      msg <- paste(msg, "duplicated taxa have been ignored!")
       if (length(unlist(duplicatedTaxa)) == 1)
           msg <- paste(msg, "duplicated taxon has been ignored!")
+      else
+          msg <- paste(msg, "duplicated taxa have been ignored!")
       if (length(unlist(duplicatedTaxa)) < 5) {
           msg <- paste(msg, "Including: ")
           msg <- c(msg, paste(unlist(duplicatedTaxa), collapse = "; "))

--- a/R/class2tree.R
+++ b/R/class2tree.R
@@ -414,9 +414,9 @@ taxonomy_table_creator <- function (nameList, rankList) {
   )
   if (length(unlist(duplicatedTaxa)) > 0) {
       msg <- paste("WARNING:", length(unlist(duplicatedTaxa)))
-      msg <- "duplicated taxa have been ignored!"
+      msg <- paste(msg, "duplicated taxa have been ignored!")
       if (length(unlist(duplicatedTaxa)) == 1)
-          msg <- "duplicated taxon has been ignored!"
+          msg <- paste(msg, "duplicated taxon has been ignored!")
       if (length(unlist(duplicatedTaxa)) < 5) {
           msg <- paste(msg, "Including: ")
           msg <- c(msg, paste(unlist(duplicatedTaxa), collapse = "; "))

--- a/tests/testthat/test-class2tree.R
+++ b/tests/testthat/test-class2tree.R
@@ -11,7 +11,8 @@ spnames <- c("Klattia flava", "Trollius sibiricus", "Arachis paraguariensis",
 dupnames <- c("Mus musculus", "Escherichia coli",
               "Haloferax denitrificans", "Mus musculus")
 
-
+duptaxa <- c("Haliotis", "Haliotis cracherodii", "Haliotis rufescens", 
+             "Megabalanus californicus")
 
 test_that("internal functions of class2tree", {
   skip_on_cran() # uses secrets
@@ -76,11 +77,20 @@ test_that("class2tree returns the correct value and class", {
     anyDuplicated(gsub("\\.\\d+$", "", names(tr$classification))), 0)
 })
 
-test_that("class2tree will abort when input contains duplicate taxa", {
+test_that("class2tree will abort when input contains duplicated taxa", {
   skip_on_cran() # uses secrets
   vcr::use_cassette("class2tree_classification_dup_call", {
     out <- classification(dupnames, db = "ncbi", messages = FALSE)
   })
   expect_error(class2tree(out),
     "Input list of classifications contains duplicates")
+})
+
+test_that("class2tree detects duplicated taxa in higher levels", {
+    skip_on_cran() # uses secrets
+    vcr::use_cassette("class2tree_classification_dup_high_level", {
+        out <- classification(duptaxa, db = "ncbi", messages = FALSE)
+    })
+    tree <- class2tree(out)
+    expect_true(nrow(tree$classification) < length(duptaxa))
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

## Description
<!--- Describe your changes in detail -->
`class2tree` can detect duplicated input taxa, which already belong to the taxonomy strings of other taxa in higher levels (e.g. genus *Haliotis* belongs to the taxonomy string of species *H. cracherodii*)

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
#934 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
```
spnames <- c("Haliotis", "Haliotis cracherodii", "Haliotis rufescens", "Megabalanus californicus", "Cadlina luteomarginata", "Anthozoa", "Gastropoda")
outTaxize <- classification(spnames, db = "gbif")
tree <- class2tree(outTaxize)
```

The duplicated taxa will be ignored with a WARNING while creating the tree

```
Get all ranks and their taxIDs
Align taxonomy hierarchies...
WARNING: 2 duplicated taxa have been ignored! Including: Haliotis; Gastropoda
Taxonomy alignment done!
Calculate distance matrix
Add node labels
```
<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
