### PR TITLE
Fix NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,6 @@ taxize 0.9.101
   - Bump `taxize` version.
   - Add `rworkflows` status badge to *README*.
 
-=============
 taxize 0.9.100
 =============
 


### PR DESCRIPTION
noticed a heading was borked in the new file on cran

See https://cloud.r-project.org/web/packages/taxize/news/news.html 

<img width="955" alt="Screenshot 2025-03-04 at 6 38 20 AM" src="https://github.com/user-attachments/assets/a5aab926-619f-4531-91f2-809ea9f12d3c" />

## Description
remove extra line of dashes

## Related Issue
none

## Example